### PR TITLE
Fix crash on unknown author/committer

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,11 +148,14 @@ function analyze (list) {
   }
   var condensed = {}
   list.forEach(function (commit) {
-    var author = commit.author ? commit.author.login : commit.committer.login
-    if (!condensed[author]) {
-      condensed[author] = []
+    var author = commit.author && commit.author.login
+    var committer = commit.committer && commit.committer.login
+    var contributor = author || committer || 'unknown'
+
+    if (!condensed[contributor]) {
+      condensed[contributor] = []
     }
-    condensed[author].push(commit.commit.message)
+    condensed[contributor].push(commit.commit.message)
   })
   Object.keys(condensed).sort(function (a, b) {
     return condensed[b].length - condensed[a].length


### PR DESCRIPTION
When a GitHub user account has been deleted, the contribution script will crash. This fix assigns a commit to 'unknown' if no author or committer could be determined.
